### PR TITLE
UTC interface

### DIFF
--- a/src/main/scala/org/widok/moment/Date.scala
+++ b/src/main/scala/org/widok/moment/Date.scala
@@ -23,6 +23,8 @@ trait Date extends js.Object with Getters with Setters[Date] {
   def isoWeekday(newDay: Int): Date = js.native
   def diff(date: Date): Duration = js.native
   def diff(date: Date, unit: String): Duration = js.native
+  def local(): Date = js.native
+  def utc(): Date = js.native
   def utcOffset(): Int = js.native
   def utcOffset(newOffset: String): Int = js.native
   def utcOffset(newOffset: Int): Int = js.native

--- a/src/main/scala/org/widok/moment/Moment.scala
+++ b/src/main/scala/org/widok/moment/Moment.scala
@@ -20,6 +20,21 @@ object Moment extends js.Object {
   def apply(string: String, format: String, strict: Boolean): Date = js.native
   def apply(string: String, format: String, locale: String, strict: Boolean): Date = js.native
 
+  def utc(): Date = js.native
+
+  /* Long has different semantics than JavaScript's numbers, therefore Double
+   * must be used.
+   */
+  def utc(millis: Double): Date = js.native
+
+  def utc(arr: js.Array[Int]): Date = js.native
+  def utc(string: String): Date = js.native
+  def utc(string: String, format: String): Date = js.native
+  def utc(string: String, formats: js.Array[String]): Date = js.native
+  def utc(string: String, format: String, locale: String): Date = js.native
+  def utc(moment: Date): Date = js.native
+  def utc(date: js.Date): Date = js.native
+
   def locale(s: String): Unit = js.native
 
   def duration(millis: Int): Duration = js.native


### PR DESCRIPTION
This exposes the Moment.js [UTC constructors](http://momentjs.com/docs/#/parsing/utc/) as well as the mutators [`moment#local()`](http://momentjs.com/docs/#/manipulating/local/) and [`moment#utc()`](http://momentjs.com/docs/#/manipulating/utc/).
