### PR TITLE
Fixes around the 'diff' method

### DIFF
--- a/src/main/scala/org/widok/moment/Date.scala
+++ b/src/main/scala/org/widok/moment/Date.scala
@@ -22,8 +22,9 @@ trait Date extends js.Object with Getters with Setters[Date] {
   def isAfter(date: Date, unit: String): Boolean = js.native
   def isoWeekday(): Int = js.native
   def isoWeekday(newDay: Int): Date = js.native
-  def diff(date: Date): Duration = js.native
-  def diff(date: Date, unit: String): Duration = js.native
+  def diff(date: Date): Int = js.native
+  def diff(date: Date, unit: String): Int = js.native
+  def diff(date: Date, unit: String, asFloat: Boolean): Double = js.native
   def local(): Date = js.native
   def utc(): Date = js.native
   def utcOffset(): Int = js.native


### PR DESCRIPTION
Fixed .diff methods return types according to
https://github.com/moment/moment/blob/master/src/lib/moment/diff.js
Added .diff overload with additional parameter “asFloat” and return
type Double
