### PR TITLE
Fix utcOffset to return double (Int sometimes fails at runtime)

### DIFF
--- a/src/main/scala/org/widok/moment/Date.scala
+++ b/src/main/scala/org/widok/moment/Date.scala
@@ -42,9 +42,9 @@ trait Date extends js.Object with Getters with Setters[Date] {
   def diff(date: Date, unit: String, asFloat: Boolean): Double = js.native
   def local(): Date = js.native
   def utc(): Date = js.native
-  def utcOffset(): Int = js.native
-  def utcOffset(newOffset: String): Int = js.native
-  def utcOffset(newOffset: Int): Int = js.native
+  def utcOffset(): Double = js.native
+  def utcOffset(newOffset: String): Double = js.native
+  def utcOffset(newOffset: Int): Double = js.native
 
   def unix(): Double = js.native
 


### PR DESCRIPTION
Hey!
This one is tricky.
With utcOffset returning Int I got runtime error on Travis. After some investigation I minimized the example:

https://github.com/vpavkin/moment-utc-offset-failure-demo, and the build
https://travis-ci.org/vpavkin/moment-utc-offset-failure-demo/builds/168286702

Making it return double fixes the issue.
