### PR TITLE
Declare main moment functionality as a trait rather than object

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,13 +6,15 @@ name := "Scala.js façade for Moment.js"
 
 normalizedName := "scala-js-momentjs"
 
-version := "0.9.1"
+version := "0.9.2-SNAPSHOT"
 
 organization := "ru.pavkin"
 
 scalaVersion := "2.12.4"
 
 crossScalaVersions := Seq("2.11.11", "2.12.4")
+
+scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) }
 
 val MomentTimezoneVersion = "0.5.14"
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.21")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.22")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
 
-addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.9.0")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.12.0")

--- a/src/main/scala/moment/Moment.scala
+++ b/src/main/scala/moment/Moment.scala
@@ -3,9 +3,8 @@ package moment
 import scala.scalajs.js
 import scala.scalajs.js.annotation.JSImport
 
-@JSImport("moment-timezone", JSImport.Namespace, "moment")
 @js.native
-object Moment extends js.Object {
+trait Moment extends js.Object {
   def apply(): Date = js.native
 
   /* Long has different semantics than JavaScript's numbers, therefore Double
@@ -57,3 +56,8 @@ object Moment extends js.Object {
 
   def tz: Timezone = js.native
 }
+
+@JSImport("moment-timezone", JSImport.Namespace, "moment")
+@js.native
+object Moment extends Moment
+


### PR DESCRIPTION
Using a trait makes it easier to produce facades for libraries that
extend the moment library (e.g. fullcalendar). A companion object is also declared so
as not to break previous usage - however it should be noted from the
http://momentjs.com/docs/ that the globally exported object is now
deprecated.

also updated some sbt plug-ins