### PR TITLE
Revert "support isoWeekDay()"

### DIFF
--- a/src/main/scala/moment/Getters.scala
+++ b/src/main/scala/moment/Getters.scala
@@ -9,7 +9,6 @@ trait Getters extends js.Object {
   def minute(): Int = js.native
   def hour(): Int = js.native
   def day(): Int = js.native
-  def isoWeekday(): Int = js.native
   def month(): Int = js.native
   def year(): Int = js.native
   def date(): Int = js.native


### PR DESCRIPTION
Reverts vpavkin/scala-js-momentjs#38

this method is only supported by moment datetime instance, makes no sense to lift it up to Getters