### PR TITLE
Cross compile to Scala.js 1.0.0-M8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: scala
 scala:
-  - 2.11.12
   - 2.12.8
   - 2.13.0
 
@@ -10,6 +9,10 @@ sudo: required
 
 jdk:
   - oraclejdk8
+
+env:
+  - SCALAJS_VERSION=0.6.31
+  - SCALAJS_VERSION=1.0.0-M8
 
 cache:
   directories:

--- a/build.sbt
+++ b/build.sbt
@@ -8,9 +8,9 @@ normalizedName := "scala-js-momentjs"
 
 organization := "ru.pavkin"
 
-scalaVersion := "2.12.8"
+scalaVersion := "2.12.10"
 
-crossScalaVersions := Seq("2.11.12", "2.12.8", "2.13.0")
+crossScalaVersions := Seq("2.12.10", "2.13.0")
 
 scalaJSLinkerConfig ~= {
   _.withModuleKind(ModuleKind.CommonJSModule)
@@ -24,7 +24,7 @@ npmDependencies in Compile ++= npmDeps
 npmDependencies in Test ++= npmDeps
 
 val MomentTimezoneVersion = "0.5.25"
-val ScalaTestVersion = "3.0.8"
+val ScalaTestVersion = "3.1.0"
 
 libraryDependencies ++= Seq(
   "org.scalatest" %%% "scalatest" % ScalaTestVersion % "test"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,12 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.28")
+val scalaJSVersion =
+  Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.31")
+
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0-M2")
 
-addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.13.1")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.16.0")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.11")


### PR DESCRIPTION
Cross compile to Scala.js 1.0.0-M8. ScalaTest 3.1.0. Drop Scala 2.11

ScalaTest supports only Scala.js 1.0.0-M8.
There is PR to update it:  https://github.com/scalatest/scalatest/pull/1731