### PR TITLE
i48 Specify minimum version of moment to avoid official vulnerabilities

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,15 +14,17 @@ scalaJSLinkerConfig ~= {
   _.withModuleKind(ModuleKind.CommonJSModule)
 }
 
+val MomentVersion = ">=2.29.4"
+val MomentTimezoneVersion = "0.5.35"
+val ScalaTestVersion = "3.2.13"
+
 lazy val npmDeps = Seq(
-  "moment-timezone" -> MomentTimezoneVersion
+  "moment" -> MomentVersion,
+  "moment-timezone" -> MomentTimezoneVersion,
 )
 
 npmDependencies in Compile ++= npmDeps
 npmDependencies in Test ++= npmDeps
-
-val MomentTimezoneVersion = "0.5.35"
-val ScalaTestVersion = "3.2.13"
 
 libraryDependencies ++= Seq(
   "org.scalatest" %%% "scalatest" % ScalaTestVersion % "test",


### PR DESCRIPTION
Specify minimum version 2.29.4 to address vulnerabilities:
- CVE-2022-24785
- CVE-2022-31129

Move the version definitions to above where they are referenced