### PR TITLE
Release from CI on v* tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: sbt
+
+      - uses: sbt/setup-sbt@v1
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Import GPG key
+        run: echo "$PGP_SECRET" | base64 --decode | gpg --batch --import
+        env:
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+
+      - name: Test, publish and release to Sonatype Central
+        run: sbt clean test publishSigned sonatypeCentralRelease
+        env:
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Everything goes through sbt (sbt 1.12.x, Scala 2.13, Scala.js 1.22.0):
 - `sbt compile` — compile
 - `sbt test` — run all tests (compiles to JS and runs under Node.js; requires Node installed, scalajs-bundler installs npm deps automatically)
 - `sbt "testOnly compatibilty.MomentSpec"` — run a single test suite (note the package is spelled `compatibilty`, not `compatibility`)
-- `sbt release` — publish a release via sbt-release/sbt-sonatype (requires PGP key and Sonatype credentials in `project/credentials.sbt`, which is not checked in)
+- `sbt release` — cut a release: bumps versions, tags, and pushes; the `v*` tag push triggers `.github/workflows/release.yml`, which signs and publishes to Sonatype Central (secrets: `SONATYPE_USERNAME`, `SONATYPE_PASSWORD`, `PGP_SECRET`, `PGP_PASSPHRASE`)
 
 ## Architecture
 
@@ -29,7 +29,7 @@ Everything goes through sbt (sbt 1.12.x, Scala 2.13, Scala.js 1.22.0):
 
 ## CI
 
-GitHub Actions (`.github/workflows/ci.yml`) runs `sbt clean test` on pushes to master and on pull requests (JDK 17, Node 20).
+GitHub Actions (`.github/workflows/ci.yml`) runs `sbt clean test` on pushes to master/maintenance branches and on pull requests (JDK 17, Node 20). `.github/workflows/release.yml` publishes to Sonatype Central on `v*` tag pushes.
 
 ## Versioning
 

--- a/build.sbt
+++ b/build.sbt
@@ -67,8 +67,11 @@ publishTo := {
   else sonatypePublishToBundle.value
 }
 
-releasePublishArtifactsAction := PgpKeys.publishSigned.value
+pgpPassphrase := sys.env.get("PGP_PASSPHRASE").map(_.toArray)
 
+/* Publishing happens in CI: `sbt release` only bumps versions and pushes
+ * the v* tag, which triggers .github/workflows/release.yml
+ */
 releaseProcess := Seq[ReleaseStep](
   checkSnapshotDependencies,
   inquireVersions,
@@ -77,8 +80,6 @@ releaseProcess := Seq[ReleaseStep](
   setReleaseVersion,
   commitReleaseVersion,
   tagRelease,
-  publishArtifacts,
-  releaseStepCommand("sonatypeCentralRelease"),
   setNextVersion,
   commitNextVersion,
   pushChanges


### PR DESCRIPTION
sbt release now only bumps versions, tags and pushes; the tag push triggers the Release workflow which tests, signs (PGP_SECRET / PGP_PASSPHRASE) and publishes to Sonatype Central (SONATYPE_USERNAME / SONATYPE_PASSWORD).